### PR TITLE
[FEATURE] Symbolic resolution for arbitrary function offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +295,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -325,6 +365,12 @@ name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "errno"
@@ -397,16 +443,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "goblin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "gpu_probe"
 version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
  "clap",
+ "goblin",
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
  "nix",
+ "proc-maps",
  "prometheus-client",
  "tokio",
 ]
@@ -534,6 +599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +670,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +711,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchit"
@@ -643,6 +747,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -675,6 +785,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -749,12 +869,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-maps"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db44c5aa60e193a25fcd93bb9ed27423827e8f118897866f946e2cf936c44fb"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "libc",
+ "libproc",
+ "mach2",
+ "winapi",
 ]
 
 [[package]]
@@ -834,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +1019,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "semver"
@@ -1167,6 +1343,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ axum = "0.7.7"
 tokio = { version = "1.41.0", features = ["rt-multi-thread", "macros"] }
 chrono = "0.4.38"
 nix = { version = "0.29.0", features = ["process", "signal"] }
+goblin = "0.9.2"
+proc-maps = "0.4.0"

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -96,6 +96,7 @@ impl Gpuprobe {
                     ));
                 }
             };
+            self.glob_process_table.create_entry(event.pid)?;
             self.memleak_state.handle_event(event)?;
         }
         Ok(())

--- a/src/gpuprobe/process_state.rs
+++ b/src/gpuprobe/process_state.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use super::GpuprobeError;
+use goblin::Object;
+use proc_maps::get_process_maps;
+
+pub struct GlobalProcessTable {
+    per_process_tables: HashMap<u32, ProcessState>,
+}
+
+impl GlobalProcessTable {
+    /// Returns a new GlobalProcessTable
+    pub fn new() -> Self {
+        return GlobalProcessTable {
+            per_process_tables: HashMap::new(),
+        };
+    }
+
+    /// Creates an entry in the per-process symbols table if it doesn't yet
+    /// exist. If an entry already exists, simply returns.
+    /// Since the data inside of `/proc/{pid}/exe` is static, and reading the
+    /// file is relatively expensive, we enforce that it is only done once
+    /// per process.
+    pub fn create_entry(&mut self, pid: u32) -> Result<(), GpuprobeError> {
+        if self.per_process_tables.contains_key(&pid) {
+            return Ok(());
+        }
+
+        let new_entry = ProcessState::new(pid)?;
+        self.per_process_tables.insert(pid, new_entry);
+        Ok(())
+    }
+
+    /// Removes the entry for pid in the per-process symbols table.
+    pub fn remove_entry(&mut self, pid: u32) {
+        self.per_process_tables.remove(&pid);
+    }
+
+    /// Resolves the symbol of an offset within the .text section of the
+    /// binary executed by this process. Returns None if out of bounds, or
+    /// doesn't point to a valid symbol
+    pub fn resolve_symbol_text_offset(&self, pid: u32, virtual_offset: u64) -> Option<String> {
+        let proc_state = match self.per_process_tables.get(&pid) {
+            Some(ps) => ps,
+            None => {
+                return None;
+            }
+        };
+
+        proc_state.resolve_symbol_text_offset(virtual_offset)
+    }
+}
+
+impl std::fmt::Display for GlobalProcessTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (_, table) in self.per_process_tables.iter() {
+            write!(f, "{table}")?;
+        }
+        Ok(())
+    }
+}
+
+/// ProcessState wraps the virtual base address (after address-space layout
+/// randomization) and elf-symbol table. We want to enable fast lookups to the
+/// symbol table of a process in order to resolve CUDA kernel addresses to
+/// a more human-readable name.
+/// Creating a new ProcessState likely incurs some overhead as it involves
+/// reading from the `/proc` pseudo-filesystem. Since this data is static, the
+/// caller should only be create at most one ProcessState per process.
+pub struct ProcessState {
+    pid: u32,
+    base_addr: u64,
+    elf_symbol_table: HashMap<u64, String>,
+}
+
+impl ProcessState {
+    pub fn new(pid: u32) -> Result<Self, GpuprobeError> {
+        let bin_path = match std::fs::read_link(format!("/proc/{}/exe", pid)) {
+            Ok(p) => p,
+            Err(e) => return Err(GpuprobeError::RuntimeError(format!("{e:?}"))),
+        };
+
+        let maps = match get_process_maps(pid as i32) {
+            Ok(m) => m,
+            Err(e) => return Err(GpuprobeError::RuntimeError(format!("{e:?}"))),
+        };
+
+        let base = match maps
+            .into_iter()
+            .find(|m| m.filename().map_or(false, |f| f == bin_path))
+            .map(|m| m.start())
+        {
+            Some(base) => base,
+            None => {
+                return Err(GpuprobeError::RuntimeError(
+                    "unable to find binary base".to_string(),
+                ));
+            }
+        } as u64;
+
+        let buff =
+            std::fs::read(bin_path).map_err(|e| GpuprobeError::RuntimeError(format!("{e:?}")))?;
+        let obj =
+            Object::parse(&buff).map_err(|e| GpuprobeError::RuntimeError(format!("{e:?}")))?;
+
+        let symbols: HashMap<u64, String> = if let Object::Elf(elf) = obj {
+            let syms = elf
+                .syms
+                .iter()
+                .filter_map(|sym| {
+                    let name = elf.strtab.get_at(sym.st_name).unwrap_or("UNDEFINED");
+                    Some((sym.st_value, name.to_string()))
+                })
+                .collect();
+            syms
+        } else {
+            return Err(GpuprobeError::RuntimeError(format!(
+                "no `/proc` entry for pid: {pid}"
+            )));
+        };
+
+        Ok(ProcessState {
+            pid,
+            base_addr: base,
+            elf_symbol_table: symbols,
+        })
+    }
+
+    /// Resolves the symbol of an offset within the .text section of the
+    /// binary executed by this process. Returns None if out of bounds, or
+    /// doesn't point to a valid symbol
+    pub fn resolve_symbol_text_offset(&self, virtual_offset: u64) -> Option<String> {
+        self.elf_symbol_table
+            .get(&(virtual_offset - self.base_addr))
+            .cloned()
+    }
+}
+
+impl std::fmt::Display for ProcessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "process {}, with base {:x}", self.pid, self.base_addr)?;
+        for (addr, symbol) in self.elf_symbol_table.iter() {
+            writeln!(f, "\t{:016x} -> {}", addr, symbol)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Motivation

This PR proposes a new struct that is used for maintaining a cache of useful process state. This is part of the effort for implementing #9 , which will be addressed in a separate PR.

We want to be able to display the following sort of output to for arbitrary CUDA kernels / programs.

```
2024-12-08 16:21:15

total kernel launches: 1136
pid: 1253276
        0x64a5af7dba50 (_Z27optimized_convolution_part1PdS_i) -> 568
        0x64a5af7dbb30 (_Z27optimized_convolution_part2PdS_i) -> 568
========================
========================
2024-12-08 16:21:18

total kernel launches: 2000
pid: 1253276
        0x64a5af7dba50 (_Z27optimized_convolution_part1PdS_i) -> 1000
        0x64a5af7dbb30 (_Z27optimized_convolution_part2PdS_i) -> 1000
========================

```

## TODO

The global process state table is maintained by the top-level `GPUprobe` struct instance, not by the sub-routines _(memleak, cudatrace)_. Thus the maintenance of the mappings is currently done in multiple places. We may need to look for a better way to do this, but it is functional at this stage.