### PR TITLE
[FEATURE] Cudatrace/kernel symbol resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,73 +48,30 @@ Grafana.
 These metrics are also displayed periodically to stdout.
 
 ```
-sudo ./gpu_probe --memleak --display-interval 3 --metrics-addr 0.0.0.0:9000
-========================
-2024-12-02 12:36:56
+2024-12-12 16:32:46
 
-num_successful_mallocs:  0
-num_failed_mallocs:      0
-num_successful_frees:    0
-num_failed_frees:        0
-per-process memory maps:
-
-========================
-========================
-2024-12-02 12:36:59
-
-num_successful_mallocs:  3
-num_failed_mallocs:      0
-num_successful_frees:    0
-num_failed_frees:        0
-per-process memory maps:
-process 246649
-        0x00007989d8000000: 8000000 Bytes
-        0x00007989dcc00000: 8000000 Bytes
-        0x00007989dd400000: 8000000 Bytes
-
-========================
-========================
-2024-12-02 12:37:11
-
-num_successful_mallocs:  3
-num_failed_mallocs:      0
-num_successful_frees:    0
-num_failed_frees:        0
-per-process memory maps:
-process 246649
-        0x00007989d8000000: 8000000 Bytes
-        0x00007989dcc00000: 8000000 Bytes
-        0x00007989dd400000: 8000000 Bytes
-
-========================
-========================
-2024-12-02 12:37:14
-
-num_successful_mallocs:  3
+num_successful_mallocs:  6
 num_failed_mallocs:      0
 num_successful_frees:    2
 num_failed_frees:        0
 per-process memory maps:
-process 246649
-        0x00007989d8000000: 8000000 Bytes
-        0x00007989dcc00000: 0 Bytes
-        0x00007989dd400000: 0 Bytes
+process 365159
+        0x0000793a44000000: 8000000 Bytes
+        0x0000793a48c00000: 8000000 Bytes
+        0x0000793a49400000: 8000000 Bytes
+process 365306
+        0x000078fd20000000: 8000000 Bytes
+        0x000078fd24c00000: 0 Bytes
+        0x000078fd25400000: 0 Bytes
 
-========================
-========================
-2024-12-02 12:37:17
+total kernel launches: 1490
+pid: 365306
+        0x5823e39efa50 (unknown kernel) -> 10
+        0x5823e39efb30 (unknown kernel) -> 10
+pid: 365159
+        0x5de98f9fba50 (_Z27optimized_convolution_part1PdS_i) -> 735
+        0x5de98f9fbb30 (_Z27optimized_convolution_part2PdS_i) -> 735
 
-num_successful_mallocs:  3
-num_failed_mallocs:      0
-num_successful_frees:    2
-num_failed_frees:        0
-per-process memory maps:
-process 246649
-        0x00007989d8000000: 0 Bytes # note: this allocation is freed by process terminating
-        0x00007989dcc00000: 0 Bytes
-        0x00007989dd400000: 0 Bytes
-
-========================
 ```
 
 The various features are opt-in via command-line arguments passed to the 

--- a/src/gpuprobe/gpuprobe_cudatrace.rs
+++ b/src/gpuprobe/gpuprobe_cudatrace.rs
@@ -5,9 +5,10 @@ mod gpuprobe {
     ));
 }
 
-use libbpf_rs::{MapCore, MapFlags, UprobeOpts};
+use std::collections::{BTreeMap, HashMap};
 
-use super::uprobe_data::CudaTraceData;
+use libbpf_rs::{MapCore, UprobeOpts};
+
 use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
 
 /// contains implementations for the cudatrace program
@@ -33,36 +34,104 @@ impl Gpuprobe {
         Ok(())
     }
 
-    /// returns the histogram of frequencies of CUDA kernels
-    /// TODO: symbol resolution - right now if we launch the same program
-    /// twice, we cannot recognize that the same kernel was launched due to
-    /// ASLR and other factors. We would ideally like to resolve which kernel
-    /// is being launched by looking at the relative addresses inside of the
-    /// cuda binary.
-    pub fn collect_data_cudatrace(&self) -> Result<CudaTraceData, GpuprobeError> {
-        let hist: Vec<(u64, u64)> = self
+    /// Consumes from the cudatrace event queue and updates cudatrace_state
+    pub fn consume_cudatrace_events(&mut self) -> Result<(), GpuprobeError> {
+        let key: [u8; 0] = []; // key size must be zero for BPF_MAP_TYPE_QUEUE
+                               // `lookup_and_delete` calls.
+        while let Ok(opt) = self
             .skel
             .skel
             .maps
-            .kernel_calls_hist
-            .keys()
-            .map(|addr| {
-                let key: [u8; 8] = addr.try_into().expect("unable to convert addr");
-                let call_count = self
-                    .skel
-                    .skel
-                    .maps
-                    .kernel_calls_hist
-                    .lookup(&key, MapFlags::ANY)
-                    .expect("lookup failed")
-                    .unwrap_or(u64::to_ne_bytes(0u64).to_vec());
-                let call_count: [u8; 8] = call_count.try_into().expect("unable to convert count");
-                (u64::from_ne_bytes(key), u64::from_ne_bytes(call_count))
-            })
-            .collect();
+            .kernel_launch_events_queue
+            .lookup_and_delete(&key)
+        {
+            let event_bytes = match opt {
+                Some(b) => b,
+                None => {
+                    // empty queue
+                    return Ok(());
+                }
+            };
+            let event = match KernelLaunchEvent::from_bytes(&event_bytes) {
+                Some(e) => e,
+                None => {
+                    return Err(GpuprobeError::RuntimeError(
+                        "unable to construct MemleakEvent from bytes".to_string(),
+                    ));
+                }
+            };
+            self.glob_process_table.create_entry(event.pid)?;
+            self.cudatrace_state.handle_event(event)?;
+        }
 
-        Ok(CudaTraceData {
-            kernel_frequencies_histogram: hist,
-        })
+        Ok(())
+    }
+}
+
+/// Represents a CUDA kernel function address as it is found in the .text
+/// section of the binary running on the host. We distinguish between a raw
+/// unresolved address, and a resolved symbol
+pub enum KernelAddress {
+    Raw(u64),
+    Symbol(String),
+}
+
+impl std::fmt::Display for KernelAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KernelAddress::Raw(addr) => write!(f, "0x{:x}", addr),
+            KernelAddress::Symbol(symbol) => write!(f, "{symbol}"),
+        }
+    }
+}
+
+pub struct CudatraceState {
+    /// maps PID to a frequency histogram
+    pub kernel_freq_hist: HashMap<u32, BTreeMap<u64, u64>>,
+    pub total_kernel_launches: u64,
+}
+
+impl CudatraceState {
+    pub fn new() -> Self {
+        return CudatraceState {
+            kernel_freq_hist: HashMap::new(),
+            total_kernel_launches: 0u64,
+        };
+    }
+
+    fn handle_event(&mut self, data: KernelLaunchEvent) -> Result<(), GpuprobeError> {
+        self.total_kernel_launches += 1;
+        if !self.kernel_freq_hist.contains_key(&data.pid) {
+            self.kernel_freq_hist.insert(data.pid, BTreeMap::new());
+        }
+
+        let b_tree_map = self.kernel_freq_hist.get_mut(&data.pid).unwrap();
+
+        if !b_tree_map.contains_key(&data.kern_offset) {
+            b_tree_map.insert(data.kern_offset, 1u64);
+        } else {
+            *b_tree_map.get_mut(&data.kern_offset).unwrap() += 1;
+        }
+        Ok(())
+    }
+}
+
+struct KernelLaunchEvent {
+    timestamp: u64,
+    kern_offset: u64,
+    pid: u32,
+}
+
+impl KernelLaunchEvent {
+    /// Constructs a KernelLaunchEvent struct from a raw byte array and returns
+    /// it, or None if the byte array isn't correctly sized.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < std::mem::size_of::<Self>() {
+            return None;
+        }
+        // This is safe if:
+        // 1. The byte array contains valid data for this struct
+        // 2. The byte array is at least as large as the struct
+        unsafe { Some(std::ptr::read_unaligned(bytes.as_ptr() as *const Self)) }
     }
 }

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -98,6 +98,8 @@ impl Gpuprobe {
             };
             self.glob_process_table.create_entry(event.pid)?;
             self.memleak_state.handle_event(event)?;
+
+            println!("{}", self.glob_process_table);
         }
         Ok(())
     }

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -98,8 +98,6 @@ impl Gpuprobe {
             };
             self.glob_process_table.create_entry(event.pid)?;
             self.memleak_state.handle_event(event)?;
-
-            println!("{}", self.glob_process_table);
         }
         Ok(())
     }

--- a/src/gpuprobe/metrics.rs
+++ b/src/gpuprobe/metrics.rs
@@ -15,6 +15,13 @@ pub struct MemleakLabelSet {
     pub offset: u64,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct CudatraceLabelSet {
+    pub pid: u32,
+    pub kernel_offset: u64,
+    pub kernel_symbol: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct GpuprobeMetrics {
     opts: Opts,
@@ -22,7 +29,7 @@ pub struct GpuprobeMetrics {
     pub num_mallocs: Gauge,
     pub memleaks: Family<MemleakLabelSet, Gauge>,
     // cuda trace
-    pub kernel_launches: Family<AddrLabel, Gauge>,
+    pub kernel_launches: Family<CudatraceLabelSet, Gauge>,
 }
 
 impl GpuprobeMetrics {

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -4,6 +4,7 @@ pub mod gpuprobe_memleak;
 pub mod metrics;
 pub mod process_state;
 pub mod uprobe_data;
+pub mod process_state;
 
 use chrono::Local;
 use metrics::GpuprobeMetrics;
@@ -22,6 +23,10 @@ mod gpuprobe {
 }
 use gpuprobe::*;
 
+<<<<<<< HEAD
+=======
+use self::{gpuprobe_memleak::MemleakState, process_state::GlobalProcessTable};
+>>>>>>> d20352d (Added struct definition for parsing process state from a PID. This will)
 use self::metrics::AddrLabel;
 use self::{gpuprobe_memleak::MemleakState, process_state::GlobalProcessTable};
 


### PR DESCRIPTION
This PR adds the ability to resolve a CUDA kernel's symbol _(function name)_ from a compiled binary at runtime. If this resolution is not possible, `unknown kernel` is displayed - manual testing shows that this happens when a process exits before the program was able to read its process state from `/proc`, although there are likely other cases that would cause this to fail.

This program also migrates cudatrace to an event-handling design, as is the case for memleak.

Example output:

```
2024-12-12 15:55:41

total kernel launches: 4781
pid: 236613
        0x5823d0fdca50 (_Z27optimized_convolution_part1PdS_i) -> 2381
        0x5823d0fdcb30 (_Z27optimized_convolution_part2PdS_i) -> 2380
pid: 236491
        0x5e6af3489a50 (unknown kernel) -> 10
        0x5e6af3489b30 (unknown kernel) -> 10
``` 

# Related PRs / issues

- Closes #9 
- Builds on #10 
