### PR TITLE
[PORTABILITY] Added optional arg for configuring libcudart location

### DIFF
--- a/src/gpuprobe/gpuprobe_bandwidth_util.rs
+++ b/src/gpuprobe/gpuprobe_bandwidth_util.rs
@@ -8,7 +8,7 @@ mod gpuprobe {
 use libbpf_rs::{MapCore, UprobeOpts};
 
 use super::uprobe_data::BandwidthUtilData;
-use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
+use super::{Gpuprobe, GpuprobeError};
 
 impl Gpuprobe {
     /// attaches uprobes for the bandwidth util program, or returns an error on
@@ -31,7 +31,7 @@ impl Gpuprobe {
             .skel
             .progs
             .trace_cuda_memcpy
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_memcpy)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_memcpy)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         let cuda_memcpy_uretprobe_link = self
@@ -39,7 +39,7 @@ impl Gpuprobe {
             .skel
             .progs
             .trace_cuda_memcpy_ret
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_memcpy_ret)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_memcpy_ret)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         self.links.links.trace_cuda_memcpy = Some(cuda_memcpy_uprobe_link);

--- a/src/gpuprobe/gpuprobe_cudatrace.rs
+++ b/src/gpuprobe/gpuprobe_cudatrace.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use libbpf_rs::{MapCore, UprobeOpts};
 
-use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
+use super::{Gpuprobe, GpuprobeError};
 
 /// contains implementations for the cudatrace program
 impl Gpuprobe {
@@ -27,7 +27,7 @@ impl Gpuprobe {
             .skel
             .progs
             .trace_cuda_launch_kernel
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_launch_kernel)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_launch_kernel)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         self.links.links.trace_cuda_launch_kernel = Some(cuda_launch_kernel_uprobe_link);

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -1,6 +1,6 @@
 use libbpf_rs::{MapCore, MapFlags, UprobeOpts};
 
-use super::{Gpuprobe, GpuprobeError, LIBCUDART_PATH};
+use super::{Gpuprobe, GpuprobeError};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// contains implementation for the memleak program
@@ -37,7 +37,7 @@ impl Gpuprobe {
             .skel
             .progs
             .memleak_cuda_malloc
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_malloc)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_malloc)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         let cuda_malloc_uretprobe_link = self
@@ -45,7 +45,7 @@ impl Gpuprobe {
             .skel
             .progs
             .memleak_cuda_malloc_ret
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_malloc_ret)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_malloc_ret)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         let cuda_free_uprobe_link = self
@@ -53,7 +53,7 @@ impl Gpuprobe {
             .skel
             .progs
             .trace_cuda_free
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_free)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_free)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         let cuda_free_uretprobe_link = self
@@ -61,7 +61,7 @@ impl Gpuprobe {
             .skel
             .progs
             .trace_cuda_free_ret
-            .attach_uprobe_with_opts(-1, LIBCUDART_PATH, 0, opts_free_ret)
+            .attach_uprobe_with_opts(-1, &self.opts.libcudart_path, 0, opts_free_ret)
             .map_err(|_| GpuprobeError::AttachError)?;
 
         self.links.links.memleak_cuda_malloc = Some(cuda_malloc_uprobe_link);

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -25,8 +25,6 @@ use gpuprobe::*;
 use self::gpuprobe_cudatrace::CudatraceState;
 use self::{gpuprobe_memleak::MemleakState, process_state::GlobalProcessTable};
 
-const LIBCUDART_PATH: &str = "/usr/local/cuda/lib64/libcudart.so";
-
 pub struct SafeGpuprobeLinks {
     links: GpuprobeLinks,
 }
@@ -74,6 +72,7 @@ pub struct Opts {
     pub memleak: bool,
     pub cudatrace: bool,
     pub bandwidth_util: bool,
+    pub libcudart_path: String,
 }
 
 const DEFAULT_LINKS: GpuprobeLinks = GpuprobeLinks {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ struct Args {
     /// Interval in seconds for displaying metrics to stdout.
     #[arg(long, default_value_t = 5)]
     display_interval: u64,
+
+    #[arg(long, default_value = "/usr/local/cuda/lib64/libcudart.so")]
+    libcudart_path: String,
 }
 
 #[derive(Clone)]
@@ -47,6 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         memleak: args.memleak,
         cudatrace: args.cudatrace,
         bandwidth_util: args.bandwidth_util,
+        libcudart_path: args.libcudart_path,
     };
 
     let mut gpuprobe = gpuprobe::Gpuprobe::new(opts).unwrap();


### PR DESCRIPTION
Allows the user to configure the location of the `libcudart.so` dynamic lib that is monitored by the program. This also allows for using multiple different `libcudart.so` files _(conda will, for example, make a copy of the file inside of the env directory)_.

The user passes this as an arg to the binary, which defaults to `/usr/local/cuda/lib64/libcudart.so`.