### PR TITLE
[FEATURE] per-process error histograms for `cudaMalloc/cudaFree` errors.

### DIFF
--- a/src/gpuprobe/cuda_error.rs
+++ b/src/gpuprobe/cuda_error.rs
@@ -83,10 +83,15 @@ impl CudaErrorState {
 impl std::fmt::Display for CudaErrorState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "per-process error histograms:")?;
-        for (pid, hash_map) in self.error_histogram.iter() {
-            writeln!(f, "process {}", pid)?;
-            for ((event, error), count) in hash_map {
-                writeln!(f, "\t({}[{:?}]): {}", event.to_string(), error, count)?;
+
+        if self.error_histogram.is_empty() {
+            println!("\tNo errors to report");
+        } else {
+            for (pid, hash_map) in self.error_histogram.iter() {
+                writeln!(f, "process {}", pid)?;
+                for ((event, error), count) in hash_map {
+                    writeln!(f, "\t({}[{:?}]): {}", event.to_string(), error, count)?;
+                }
             }
         }
 

--- a/src/gpuprobe/cuda_error.rs
+++ b/src/gpuprobe/cuda_error.rs
@@ -35,7 +35,8 @@ impl ToString for EventType {
         match self {
             Self::CudaMalloc => "cudaMalloc",
             Self::CudaFree => "cudaFree",
-        }.to_string()
+        }
+        .to_string()
     }
 }
 
@@ -64,7 +65,7 @@ impl CudaErrorState {
 
         let hist = match self.error_histogram.get_mut(&err.pid) {
             Some(hist) => hist,
-            None => panic!("what"),
+            None => panic!("no entry for {} in histogram", err.pid),
         };
 
         let count_ref = match hist.get_mut(&(err.event, err.error)) {

--- a/src/gpuprobe/cuda_error.rs
+++ b/src/gpuprobe/cuda_error.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use super::GpuprobeError;
+
+/// Defines a subset of the enum values `enum cudaError_t` found in
+/// driver_types.h
+#[repr(i32)]
+#[derive(std::cmp::PartialEq, std::cmp::Eq, std::hash::Hash, Clone, Copy, Debug)]
+pub enum CudaErrorT {
+    CudaSuccess,
+    CudaErrorInvalidValue,
+    CudaErrorMemoryAllocation,
+    UnsupportedErrorType,
+}
+
+impl CudaErrorT {
+    pub fn from_int(value: i32) -> Self {
+        match value {
+            0 => CudaErrorT::CudaSuccess,
+            1 => CudaErrorT::CudaErrorInvalidValue,
+            2 => CudaErrorT::CudaErrorMemoryAllocation,
+            _ => CudaErrorT::UnsupportedErrorType,
+        }
+    }
+}
+
+#[derive(std::cmp::PartialEq, std::cmp::Eq, std::hash::Hash, Clone, Copy, Debug)]
+pub enum EventType {
+    CudaMalloc,
+    CudaFree,
+}
+
+impl ToString for EventType {
+    fn to_string(&self) -> String {
+        match self {
+            Self::CudaMalloc => "cudaMalloc",
+            Self::CudaFree => "cudaFree",
+        }.to_string()
+    }
+}
+
+pub struct CudaError {
+    pub pid: u32,
+    pub event: EventType,
+    pub error: CudaErrorT,
+}
+
+/// Maintains per-process error histograms
+pub struct CudaErrorState {
+    pub error_histogram: HashMap<u32, HashMap<(EventType, CudaErrorT), u64>>,
+}
+
+impl CudaErrorState {
+    pub fn new() -> Self {
+        CudaErrorState {
+            error_histogram: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, err: CudaError) -> Result<(), GpuprobeError> {
+        if !self.error_histogram.contains_key(&err.pid) {
+            self.error_histogram.insert(err.pid, HashMap::new());
+        }
+
+        let hist = match self.error_histogram.get_mut(&err.pid) {
+            Some(hist) => hist,
+            None => panic!("what"),
+        };
+
+        let count_ref = match hist.get_mut(&(err.event, err.error)) {
+            Some(r) => r,
+            None => {
+                hist.insert((err.event, err.error), 1);
+                return Ok(());
+            }
+        };
+        *count_ref += 1;
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CudaErrorState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "per-process error histograms:")?;
+        for (pid, hash_map) in self.error_histogram.iter() {
+            writeln!(f, "process {}", pid)?;
+            for ((event, error), count) in hash_map {
+                writeln!(f, "\t({}[{:?}]): {}", event.to_string(), error, count)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/gpuprobe/gpuprobe_memleak.rs
+++ b/src/gpuprobe/gpuprobe_memleak.rs
@@ -266,11 +266,16 @@ impl MemleakState {
 impl std::fmt::Display for MemleakState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "per-process memory maps:")?;
-        for (pid, b_tree_map) in self.memory_map.iter() {
-            writeln!(f, "process {}", pid)?;
 
-            for (_, alloc) in b_tree_map.iter() {
-                writeln!(f, "\t{alloc}")?;
+        if self.memory_map.is_empty() {
+            writeln!(f, "\tNo allocations on GPU")?;
+        } else {
+            for (pid, b_tree_map) in self.memory_map.iter() {
+                writeln!(f, "process {}", pid)?;
+
+                for (_, alloc) in b_tree_map.iter() {
+                    writeln!(f, "\t{alloc}")?;
+                }
             }
         }
         writeln!(f)

--- a/src/gpuprobe/metrics.rs
+++ b/src/gpuprobe/metrics.rs
@@ -10,6 +10,13 @@ pub struct AddrLabel {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct ErrorLabelSet {
+    pub pid: u32,
+    pub call_type: String,
+    pub return_code: u32,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub struct MemleakLabelSet {
     pub pid: u32,
     pub offset: u64,
@@ -25,8 +32,8 @@ pub struct CudatraceLabelSet {
 #[derive(Debug, Clone)]
 pub struct GpuprobeMetrics {
     opts: Opts,
+    pub err_hist: Family<ErrorLabelSet, Gauge>,
     // memleak metrics
-    pub num_mallocs: Gauge,
     pub memleaks: Family<MemleakLabelSet, Gauge>,
     // cuda trace
     pub kernel_launches: Family<CudatraceLabelSet, Gauge>,
@@ -36,7 +43,7 @@ impl GpuprobeMetrics {
     pub fn new(opts: Opts) -> Result<Self, GpuprobeError> {
         Ok(GpuprobeMetrics {
             opts,
-            num_mallocs: Gauge::default(),
+            err_hist: Family::default(),
             memleaks: Family::default(),
             kernel_launches: Family::default(),
         })
@@ -44,11 +51,6 @@ impl GpuprobeMetrics {
 
     pub fn register(&self, registry: &mut Registry) {
         if self.opts.memleak {
-            registry.register(
-                "total_cuda_mallocs",
-                "Total number of cudaMalloc calls",
-                self.num_mallocs.clone(),
-            );
             registry.register(
                 "cuda_memory_leaks",
                 "Cuda memory leak statistics",
@@ -61,6 +63,13 @@ impl GpuprobeMetrics {
                 "Cuda kernel launch statistics",
                 self.kernel_launches.clone(),
             );
+        }
+        if self.opts.memleak || self.opts.cudatrace {
+            registry.register(
+                "cuda_error_histogram",
+                "CUDA errors histogram keyed on process, error type and erroneous call",
+                self.err_hist.clone(),
+            )
         }
     }
 }

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -54,7 +54,7 @@ unsafe impl Sync for SafeGpuProbeObj {}
 /// Gpuuprobe wraps the eBPF program state, provides an interface for
 /// attaching relevant uprobes, and exporting their metrics.
 ///
-/// !!TODO!! maybe consider using orobouros self-referential instead of the
+/// TODO: maybe consider using orobouros self-referential instead of the
 /// static lifetime
 pub struct Gpuprobe {
     obj: SafeGpuProbeObj,


### PR DESCRIPTION
This PR proposes error observability feature implementation for the memleak programs. Namely, this introduces counters keyed on process, function type, and return code. E.g. `(12345, cudaMalloc, 2)` which signifies `CudaErrorMemoryAllocation` for a failed  `cudaMalloc()` call.

These are exported as Prometheus metrics and displayed to stdout.