### PR TITLE
[FEATURE] add error book-keeping for `cudaLaunchKernel()`

### DIFF
--- a/src/gpuprobe/cuda_error.rs
+++ b/src/gpuprobe/cuda_error.rs
@@ -7,7 +7,7 @@ use super::GpuprobeError;
 #[repr(i32)]
 #[derive(std::cmp::PartialEq, std::cmp::Eq, std::hash::Hash, Clone, Copy, Debug)]
 pub enum CudaErrorT {
-    CudaSuccess,
+    CudaSuccess = 0,
     CudaErrorInvalidValue,
     CudaErrorMemoryAllocation,
     UnsupportedErrorType,
@@ -28,6 +28,7 @@ impl CudaErrorT {
 pub enum EventType {
     CudaMalloc,
     CudaFree,
+    CudaLaunchKernel,
 }
 
 impl ToString for EventType {
@@ -35,6 +36,7 @@ impl ToString for EventType {
         match self {
             Self::CudaMalloc => "cudaMalloc",
             Self::CudaFree => "cudaFree",
+            Self::CudaLaunchKernel => "cudaLaunchKernel",
         }
         .to_string()
     }

--- a/src/gpuprobe/mod.rs
+++ b/src/gpuprobe/mod.rs
@@ -83,6 +83,7 @@ const DEFAULT_LINKS: GpuprobeLinks = GpuprobeLinks {
     trace_cuda_free: None,
     trace_cuda_free_ret: None,
     trace_cuda_launch_kernel: None,
+    trace_cuda_launch_kernel_ret: None,
     trace_cuda_memcpy: None,
     trace_cuda_memcpy_ret: None,
 };


### PR DESCRIPTION
This PR implements a new `uretprobe` for `cudaLaunchKernel()`, and updates the relevant user-space code so that errors are handled and reported in the same way as it is done for `cudaMalloc()` and `cudaFree()`.

Closes #19 